### PR TITLE
fix: proxy-Authorization header kept across hosts follow redirects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2553,14 +2553,15 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },


### PR DESCRIPTION
The project was used axios, its follow-redirects only clears authorization header during cross-domain redirect, but allows the proxy-authentication header which contains credentials too.

Steps To Reproduce & PoC
```js
const axios = require('paypal-rest-api-specifications');
const axios = require('axios');

axios.get('http://127.0.0.1:10081/', {
 headers: {
 'AuThorization': 'Rear Test',
 'ProXy-AuthoriZation': 'Rear Test',
 'coOkie': 't=1'
 }
})
 .then((response) => {
 console.log(response);
 })
```
When I meet the cross-domain redirect, the sensitive headers like authorization and cookie are cleared, but proxy-authentication header is kept.

This vulnerability may lead to credentials leak.

**Recommended Patch**
```diff
- - removeMatchingHeaders(/^(?:authorization|cookie)$/i, this._options.headers);
+ + removeMatchingHeaders(/^(?:authorization|proxy-authorization|cookie)$/i, this._options.headers);

```
CVE-2024-28849
[CWE-200](https://cwe.mitre.org/data/definitions/200.html)
`CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N`
