### PR TITLE
Fix invalid spec constraints

### DIFF
--- a/openapi/checkout_orders_v2.json
+++ b/openapi/checkout_orders_v2.json
@@ -5072,7 +5072,7 @@
         "type": "string",
         "description": "The [language tag](https://tools.ietf.org/html/bcp47#section-2) for the language in which to localize the error-related strings, such as messages, issues, and suggested actions. The tag is made up of the [ISO 639-2 language code](https://www.loc.gov/standards/iso639-2/php/code_list.php), the optional [ISO-15924 script tag](https://www.unicode.org/iso15924/codelists.html), and the [ISO-3166 alpha-2 country code](/api/rest/reference/country-codes/) or [M49 region code](https://unstats.un.org/unsd/methodology/m49/).",
         "format": "ppaas_common_language_v3",
-        "maxLength": 10,
+        "maxLength": 11,
         "minLength": 2,
         "pattern": "^[a-z]{2}(?:-[A-Z][a-z]{3})?(?:-(?:[A-Z]{2}|[0-9]{3}))?$"
       },

--- a/openapi/payments_payment_v1.json
+++ b/openapi/payments_payment_v1.json
@@ -1958,8 +1958,8 @@
           "payer_id": {
             "type": "string",
             "description": "Deprecated. A unique ID that you can assign and track when you store a credit card in the vault or use a vaulted credit card. This ID can help to avoid unintentional use or misuse of credit cards and can be any value, such as a UUID, user name, or email address. **Required** when you use a vaulted credit card and if a `payer_id` was originally provided when you vaulted the credit card. Use external_customer_id instead.",
-            "maxLength": 1,
-            "minLength": 256
+            "minLength": 1,
+            "maxLength": 256
           },
           "external_customer_id": {
             "type": "string",


### PR DESCRIPTION
These are some minor changes which fail the mock generation.
1. the regex max length is 11 characters.
2. the `min` and `max` just have to be reversed.
