### PR TITLE
Add missing PayPal-Request-Id header to authorization void

### DIFF
--- a/openapi/payments_payment_v2.json
+++ b/openapi/payments_payment_v2.json
@@ -437,6 +437,9 @@
             "$ref": "#/components/parameters/paypal_auth_assertion"
           },
           {
+            "$ref": "#/components/parameters/paypal_request_id"
+          },
+          {
             "$ref": "#/components/parameters/prefer"
           }
         ],


### PR DESCRIPTION
Add missing PayPal-Request-Id header to [/v2/payments/authorizations/{authorization_id}/void](https://developer.paypal.com/docs/api/payments/v2/#authorizations_void)