### PR TITLE
use numbers in min/maxLength

### DIFF
--- a/openapi/invoicing_v2.json
+++ b/openapi/invoicing_v2.json
@@ -6452,8 +6452,8 @@
             "type": "string",
             "description": "The ID for the invoice payment.",
             "readOnly": true,
-            "minLength": "1",
-            "maxLength": "22",
+            "minLength": 1,
+            "maxLength": 22,
             "pattern": "^[0-9A-Za-z_-]+$"
           }
         }
@@ -6731,8 +6731,8 @@
             "type": "string",
             "description": "The ID of the refund of an invoice payment.",
             "readOnly": true,
-            "minLength": "1",
-            "maxLength": "22",
+            "minLength": 1,
+            "maxLength": 22,
             "pattern": "^[0-9A-Za-z_-]+$"
           }
         }


### PR DESCRIPTION
I use oapi-codegen to generate Go code from paypal openapi spec but it currently fails.

This PR solves one of the issues.

```
failed to load OpenAPI specification: failed to unmarshal data: json error: json: cannot unmarshal string into field Schema.maxLength of type uint64
```