### PR TITLE
Nested allOf

### DIFF
--- a/openapi/checkout_orders_v2.json
+++ b/openapi/checkout_orders_v2.json
@@ -12638,14 +12638,10 @@
                 "type": "object",
                 "allOf": [
                     {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/activity_timestamps"
-                            },
-                            {
-                                "title": "activity_timestamps"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/activity_timestamps"
+                    },
+                    {
+                        "title": "activity_timestamps"
                     },
                     {
                         "type": "object",


### PR DESCRIPTION
Hi, you do not have issues open. So I am contacting you here.

You managed to duplicate `allOf` at several places:
<img width="1305" height="524" alt="image" src="https://github.com/user-attachments/assets/8d097f56-d2f7-43e8-9805-2696a206c74f" />

It breaks code generators, since this is kind of broken.

The correct version is without duplicated `allOf`:
```json
      "order_authorize_response": {
        "title": "Order Authorize Response",
        "description": "The order authorize response.",
        "type": "object",
        "allOf": [
          {
            "$ref": "#/components/schemas/activity_timestamps"
          },
          {
            "title": "activity_timestamps"
          },
          {
            "type": "object",
            "title": "Order Authorize Response",
            "description": "The order authorize response.",
            "properties": {
            }
          }
        ]
      }
```